### PR TITLE
Add jest test environment

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,12 @@
+import type { Config } from 'jest';
+
+const config: Config = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/$1',
+  },
+  roots: ['<rootDir>/lib']
+};
+
+export default config;

--- a/lib/__tests__/utils.test.ts
+++ b/lib/__tests__/utils.test.ts
@@ -1,0 +1,23 @@
+import { calculateInvoiceTotal } from '../utils';
+
+describe('calculateInvoiceTotal', () => {
+  it('calculates total with tax and discount', () => {
+    const result = calculateInvoiceTotal(200, 10, 20);
+    expect(result).toEqual({
+      subtotal: 200,
+      tax: 18,
+      discount: 20,
+      total: 198,
+    });
+  });
+
+  it('defaults discount and tax to zero', () => {
+    const result = calculateInvoiceTotal(50);
+    expect(result).toEqual({
+      subtotal: 50,
+      tax: 0,
+      discount: 0,
+      total: 50,
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest"
   },
   "dependencies": {
     "@clerk/nextjs": "^6.20.2",
@@ -45,14 +46,18 @@
   "devDependencies": {
     "@eslint/eslintrc": "^3",
     "@tailwindcss/postcss": "^4",
+    "@types/jest": "^29.5.14",
     "@types/node": "^20.17.55",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "autoprefixer": "^10.4.21",
     "eslint": "^9",
     "eslint-config-next": "15.3.2",
+    "jest": "^29.7.0",
     "postcss": "^8.5.4",
     "tailwindcss": "^3.4.17",
+    "ts-jest": "^29.3.4",
+    "ts-node": "^10.9.2",
     "typescript": "^5"
   }
 }


### PR DESCRIPTION
## Summary
- add jest dev dependencies and `npm test` script
- configure Jest with ts-jest
- test `calculateInvoiceTotal` for basic scenarios

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6840634a58108331966f3114d4ef4b15