### PR TITLE
Fix missing actionUrl in invoice delete notifications

### DIFF
--- a/lib/notification-service.ts
+++ b/lib/notification-service.ts
@@ -99,7 +99,8 @@ export class NotificationService {
           invoiceNumber: invoice.invoiceNumber,
           customerName: invoice.customer?.name,
           deletedAt: new Date()
-        }
+        },
+        actionUrl: undefined
       })
     } catch (error) {
       console.error('❌ Failed to create invoice deleted notification:', error)


### PR DESCRIPTION
## Summary
- ensure `notifyInvoiceDeleted` includes an `actionUrl`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840ae6457c08331b97fa23a19bf87e2