### PR TITLE
Handle missing user sessions

### DIFF
--- a/app/[locale]/(auth)/sign-in/page.tsx
+++ b/app/[locale]/(auth)/sign-in/page.tsx
@@ -52,6 +52,7 @@ export default function SignInForm() {
 
       if (result.status === 'complete') {
         await setActive({ session: result.createdSessionId })
+        await fetch('/api/ensure-user', { method: 'POST' })
         router.push('/dashboard')
       }
     } catch (err: unknown) {

--- a/app/[locale]/(auth)/sign-up/page.tsx
+++ b/app/[locale]/(auth)/sign-up/page.tsx
@@ -108,6 +108,7 @@ export default function SignUpForm() {
 
       if (completeSignUp.status === 'complete') {
         await setActive({ session: completeSignUp.createdSessionId })
+        await fetch('/api/ensure-user', { method: 'POST' })
         router.push('/dashboard')
       }
     } catch (err: unknown) {

--- a/app/api/customers/[id]/route.ts
+++ b/app/api/customers/[id]/route.ts
@@ -2,6 +2,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { auth } from '@clerk/nextjs/server'
 import { db } from '@/lib/db'
+import { requireDbUser } from '@/lib/auth-utils'
 import { customerSchema } from '@/lib/validations'
 import { ApiResponse, Customer } from '@/types'
 import { NotificationService } from '@/lib/notification-service'
@@ -18,25 +19,9 @@ export async function GET(
   { params }: RouteParams
 ) {
   try {
-    const { userId: clerkId } = await auth()
-    
-    if (!clerkId) {
-      return NextResponse.json(
-        { success: false, error: 'Unauthorized' } as ApiResponse,
-        { status: 401 }
-      )
-    }
-
-    const user = await db.user.findUnique({
-      where: { clerkId }
-    })
-
-    if (!user) {
-      return NextResponse.json(
-        { success: false, error: 'User not found' } as ApiResponse,
-        { status: 404 }
-      )
-    }
+    const currentUser = await requireDbUser(request)
+    if (currentUser instanceof NextResponse) return currentUser
+    const user = currentUser
 
     const customer = await db.customer.findFirst({
       where: {
@@ -89,25 +74,9 @@ export async function PUT(
   { params }: RouteParams
 ) {
   try {
-    const { userId: clerkId } = await auth()
-    
-    if (!clerkId) {
-      return NextResponse.json(
-        { success: false, error: 'Unauthorized' } as ApiResponse,
-        { status: 401 }
-      )
-    }
-
-    const user = await db.user.findUnique({
-      where: { clerkId }
-    })
-
-    if (!user) {
-      return NextResponse.json(
-        { success: false, error: 'User not found' } as ApiResponse,
-        { status: 404 }
-      )
-    }
+    const currentUser = await requireDbUser(request)
+    if (currentUser instanceof NextResponse) return currentUser
+    const user = currentUser
 
     const body = await request.json()
     const validatedData = customerSchema.parse(body)
@@ -212,26 +181,10 @@ export async function DELETE(
   request: NextRequest, { params }: { params: { id: string } }
 ) {
   try {
-    const { id } = await params;
-    const { userId: clerkId } = await auth()
-    
-    if (!clerkId) {
-      return NextResponse.json(
-        { success: false, error: 'Unauthorized' } as ApiResponse,
-        { status: 401 }
-      )
-    }
-
-    const user = await db.user.findUnique({
-      where: { clerkId }
-    })
-
-    if (!user) {
-      return NextResponse.json(
-        { success: false, error: 'User not found' } as ApiResponse,
-        { status: 404 }
-      )
-    }
+    const { id } = params
+    const currentUser = await requireDbUser(request)
+    if (currentUser instanceof NextResponse) return currentUser
+    const user = currentUser
 
     // בדיקה שהלקוח קיים ושייך למשתמש
     const customer = await db.customer.findFirst({

--- a/app/api/customers/route.ts
+++ b/app/api/customers/route.ts
@@ -2,6 +2,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { auth } from '@clerk/nextjs/server'
 import { db } from '@/lib/db'
+import { requireDbUser } from '@/lib/auth-utils'
 import { customerSchema } from '@/lib/validations'
 import { ApiResponse, Customer } from '@/types'
 import { NotificationService } from '@/lib/notification-service'
@@ -9,26 +10,10 @@ import { NotificationService } from '@/lib/notification-service'
 // GET /api/customers - קבלת כל הלקוחות של המשתמש
 export async function GET(request: NextRequest) {
   try {
-    const { userId: clerkId } = await auth()
-    
-    if (!clerkId) {
-      return NextResponse.json(
-        { success: false, error: 'Unauthorized' } as ApiResponse,
-        { status: 401 }
-      )
-    }
+    const currentUser = await requireDbUser(request)
+    if (currentUser instanceof NextResponse) return currentUser
 
-    // מציאת המשתמש בדאטהבייס
-    const user = await db.user.findUnique({
-      where: { clerkId }
-    })
-
-    if (!user) {
-      return NextResponse.json(
-        { success: false, error: 'User not found' } as ApiResponse,
-        { status: 404 }
-      )
-    }
+    const user = currentUser
 
     // קבלת פרמטרי חיפוש
     const { searchParams } = new URL(request.url)
@@ -90,26 +75,9 @@ export async function GET(request: NextRequest) {
 // POST /api/customers - יצירת לקוח חדש
 export async function POST(request: NextRequest) {
   try {
-    const { userId: clerkId } = await auth()
-    
-    if (!clerkId) {
-      return NextResponse.json(
-        { success: false, error: 'Unauthorized' } as ApiResponse,
-        { status: 401 }
-      )
-    }
-
-    // מציאת המשתמש בדאטהבייס
-    const user = await db.user.findUnique({
-      where: { clerkId }
-    })
-
-    if (!user) {
-      return NextResponse.json(
-        { success: false, error: 'User not found' } as ApiResponse,
-        { status: 404 }
-      )
-    }
+    const currentUser = await requireDbUser(request)
+    if (currentUser instanceof NextResponse) return currentUser
+    const user = currentUser
 
     const body = await request.json()
     

--- a/app/api/ensure-user/route.ts
+++ b/app/api/ensure-user/route.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from 'next/server'
+import { auth, clerkClient } from '@clerk/nextjs/server'
+import { db } from '@/lib/db'
+
+export async function POST() {
+  try {
+    const { userId } = await auth()
+    if (!userId) {
+      return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 })
+    }
+
+    let user = await db.user.findUnique({ where: { clerkId: userId } })
+
+    if (!user) {
+      const clerkUser = await clerkClient.users.getUser(userId)
+      user = await db.user.create({
+        data: {
+          clerkId: userId,
+          email: clerkUser.emailAddresses[0]?.emailAddress || '',
+          firstName: clerkUser.firstName || null,
+          lastName: clerkUser.lastName || null,
+          imageUrl: clerkUser.imageUrl || null,
+        }
+      })
+
+      await db.userSettings.create({
+        data: {
+          userId: user.id,
+          businessName: `${clerkUser.firstName || ''} ${clerkUser.lastName || ''}`.trim() || 'My Business',
+          taxRate: 17,
+          currency: 'ILS',
+          invoicePrefix: 'INV',
+          nextInvoiceNumber: 1,
+        }
+      })
+    }
+
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    console.error('Error ensuring user:', error)
+    return NextResponse.json({ success: false, error: 'Failed to ensure user' }, { status: 500 })
+  }
+}

--- a/app/api/invoices/[id]/status/route.ts
+++ b/app/api/invoices/[id]/status/route.ts
@@ -2,6 +2,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { auth } from '@clerk/nextjs/server'
 import { db } from '@/lib/db'
+import { requireDbUser } from '@/lib/auth-utils'
 import { z } from 'zod'
 import { ApiResponse, InvoiceStatus } from '@/types'
 import { NotificationService } from '@/lib/notification-service'
@@ -29,25 +30,9 @@ export async function PATCH(
 ) {
   try {
     const { id } = context.params
-    const { userId: clerkId } = await auth()
-    
-    if (!clerkId) {
-      return NextResponse.json(
-        { success: false, error: 'Unauthorized' } as ApiResponse,
-        { status: 401 }
-      )
-    }
-
-    const user = await db.user.findUnique({
-      where: { clerkId }
-    })
-
-    if (!user) {
-      return NextResponse.json(
-        { success: false, error: 'User not found' } as ApiResponse,
-        { status: 404 }
-      )
-    }
+    const currentUser = await requireDbUser(request)
+    if (currentUser instanceof NextResponse) return currentUser
+    const user = currentUser
 
     const body = await request.json()
     const validatedData = statusUpdateSchema.parse(body)

--- a/app/api/invoices/route.ts
+++ b/app/api/invoices/route.ts
@@ -2,6 +2,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { auth } from '@clerk/nextjs/server'
 import { db } from '@/lib/db'
+import { requireDbUser } from '@/lib/auth-utils'
 import { invoiceSchema } from '@/lib/validations'
 import { ApiResponse, Invoice, InvoiceStatus } from '@/types'
 import { generateInvoiceNumber, calculateInvoiceTotal } from '@/lib/utils'
@@ -10,25 +11,9 @@ import { NotificationService } from '@/lib/notification-service'
 // GET /api/invoices - קבלת כל החשבוניות של המשתמש
 export async function GET(request: NextRequest) {
   try {
-    const { userId: clerkId } = await auth()
-
-    if (!clerkId) {
-      return NextResponse.json(
-        { success: false, error: 'Unauthorized' } as ApiResponse,
-        { status: 401 }
-      )
-    }
-
-    const user = await db.user.findUnique({
-      where: { clerkId }
-    })
-
-    if (!user) {
-      return NextResponse.json(
-        { success: false, error: 'User not found' } as ApiResponse,
-        { status: 404 }
-      )
-    }
+    const currentUser = await requireDbUser(request)
+    if (currentUser instanceof NextResponse) return currentUser
+    const user = currentUser
 
     // קבלת פרמטרי חיפוש וסינון
     const { searchParams } = new URL(request.url)
@@ -118,25 +103,16 @@ export async function GET(request: NextRequest) {
 // POST /api/invoices - יצירת חשבונית חדשה
 export async function POST(request: NextRequest) {
   try {
-    const { userId: clerkId } = await auth()
-
-    if (!clerkId) {
-      return NextResponse.json(
-        { success: false, error: 'Unauthorized' } as ApiResponse,
-        { status: 401 }
-      )
-    }
-
+    const currentUser = await requireDbUser(request)
+    if (currentUser instanceof NextResponse) return currentUser
     const user = await db.user.findUnique({
-      where: { clerkId },
+      where: { id: currentUser.id },
       include: { settings: true }
     })
-
     if (!user) {
-      return NextResponse.json(
-        { success: false, error: 'User not found' } as ApiResponse,
-        { status: 404 }
-      )
+      const signInUrl = new URL('/sign-in', request.url)
+      signInUrl.searchParams.set('redirect_url', request.url)
+      return NextResponse.redirect(signInUrl)
     }
 
     const body = await request.json()

--- a/app/api/notifications/[id]/route.ts
+++ b/app/api/notifications/[id]/route.ts
@@ -2,6 +2,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { auth } from '@clerk/nextjs/server'
 import { db } from '@/lib/db'
+import { requireDbUser } from '@/lib/auth-utils'
 import { ApiResponse } from '@/types'
 
 interface RouteParams {
@@ -16,25 +17,9 @@ export async function GET(
   { params }: RouteParams
 ) {
   try {
-    const { userId: clerkId } = await auth()
-    
-    if (!clerkId) {
-      return NextResponse.json(
-        { success: false, error: 'Unauthorized' } as ApiResponse,
-        { status: 401 }
-      )
-    }
-
-    const user = await db.user.findUnique({
-      where: { clerkId }
-    })
-
-    if (!user) {
-      return NextResponse.json(
-        { success: false, error: 'User not found' } as ApiResponse,
-        { status: 404 }
-      )
-    }
+    const currentUser = await requireDbUser(request)
+    if (currentUser instanceof NextResponse) return currentUser
+    const user = currentUser
 
     const notification = await db.notification.findFirst({
       where: {
@@ -70,25 +55,9 @@ export async function PATCH(
   { params }: RouteParams
 ) {
   try {
-    const { userId: clerkId } = await auth()
-    
-    if (!clerkId) {
-      return NextResponse.json(
-        { success: false, error: 'Unauthorized' } as ApiResponse,
-        { status: 401 }
-      )
-    }
-
-    const user = await db.user.findUnique({
-      where: { clerkId }
-    })
-
-    if (!user) {
-      return NextResponse.json(
-        { success: false, error: 'User not found' } as ApiResponse,
-        { status: 404 }
-      )
-    }
+    const currentUser = await requireDbUser(request)
+    if (currentUser instanceof NextResponse) return currentUser
+    const user = currentUser
 
     const body = await request.json()
     const { read } = body
@@ -137,25 +106,9 @@ export async function DELETE(
   { params }: RouteParams
 ) {
   try {
-    const { userId: clerkId } = await auth()
-    
-    if (!clerkId) {
-      return NextResponse.json(
-        { success: false, error: 'Unauthorized' } as ApiResponse,
-        { status: 401 }
-      )
-    }
-
-    const user = await db.user.findUnique({
-      where: { clerkId }
-    })
-
-    if (!user) {
-      return NextResponse.json(
-        { success: false, error: 'User not found' } as ApiResponse,
-        { status: 404 }
-      )
-    }
+    const currentUser = await requireDbUser(request)
+    if (currentUser instanceof NextResponse) return currentUser
+    const user = currentUser
 
     // בדיקה שההתראה קיימת ושייכת למשתמש
     const notification = await db.notification.findFirst({

--- a/app/api/notifications/mark-all-read/route.ts
+++ b/app/api/notifications/mark-all-read/route.ts
@@ -2,30 +2,15 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { auth } from '@clerk/nextjs/server'
 import { db } from '@/lib/db'
+import { requireDbUser } from '@/lib/auth-utils'
 import { ApiResponse } from '@/types'
 
 // PATCH /api/notifications/mark-all-read - סימון כל ההתראות כנקראו
 export async function PATCH(request: NextRequest) {
   try {
-    const { userId: clerkId } = await auth()
-    
-    if (!clerkId) {
-      return NextResponse.json(
-        { success: false, error: 'Unauthorized' } as ApiResponse,
-        { status: 401 }
-      )
-    }
-
-    const user = await db.user.findUnique({
-      where: { clerkId }
-    })
-
-    if (!user) {
-      return NextResponse.json(
-        { success: false, error: 'User not found' } as ApiResponse,
-        { status: 404 }
-      )
-    }
+    const currentUser = await requireDbUser(request)
+    if (currentUser instanceof NextResponse) return currentUser
+    const user = currentUser
 
     // עדכון כל ההתראות הלא נקראות של המשתמש
     const result = await db.notification.updateMany({

--- a/app/api/notifications/route.ts
+++ b/app/api/notifications/route.ts
@@ -2,6 +2,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { auth } from '@clerk/nextjs/server'
 import { db } from '@/lib/db'
+import { requireDbUser } from '@/lib/auth-utils'
 import { ApiResponse, PaginatedResponse, NotificationType } from '@/types'
 
 export interface Notification {
@@ -20,26 +21,9 @@ export interface Notification {
 // GET /api/notifications - קבלת כל ההתראות של המשתמש
 export async function GET(request: NextRequest) {
   try {
-    const { userId: clerkId } = await auth()
-    
-    if (!clerkId) {
-      return NextResponse.json(
-        { success: false, error: 'Unauthorized' } as ApiResponse,
-        { status: 401 }
-      )
-    }
-
-    // מציאת המשתמש בדאטהבייס
-    const user = await db.user.findUnique({
-      where: { clerkId }
-    })
-
-    if (!user) {
-      return NextResponse.json(
-        { success: false, error: 'User not found' } as ApiResponse,
-        { status: 404 }
-      )
-    }
+    const currentUser = await requireDbUser(request)
+    if (currentUser instanceof NextResponse) return currentUser
+    const user = currentUser
 
     // קבלת פרמטרי חיפוש
     const { searchParams } = new URL(request.url)
@@ -95,25 +79,9 @@ export async function GET(request: NextRequest) {
 // POST /api/notifications - יצירת התראה חדשה (לשימוש פנימי)
 export async function POST(request: NextRequest) {
   try {
-    const { userId: clerkId } = await auth()
-    
-    if (!clerkId) {
-      return NextResponse.json(
-        { success: false, error: 'Unauthorized' } as ApiResponse,
-        { status: 401 }
-      )
-    }
-
-    const user = await db.user.findUnique({
-      where: { clerkId }
-    })
-
-    if (!user) {
-      return NextResponse.json(
-        { success: false, error: 'User not found' } as ApiResponse,
-        { status: 404 }
-      )
-    }
+    const currentUser = await requireDbUser(request)
+    if (currentUser instanceof NextResponse) return currentUser
+    const user = currentUser
 
     const body = await request.json()
     const { type, title, message, data, actionUrl, targetUserId } = body

--- a/lib/auth-utils.ts
+++ b/lib/auth-utils.ts
@@ -1,0 +1,21 @@
+import { auth } from '@clerk/nextjs/server'
+import { NextRequest, NextResponse } from 'next/server'
+import { db } from './db'
+
+export async function requireDbUser(req: NextRequest) {
+  const { userId } = await auth()
+  if (!userId) {
+    const signInUrl = new URL('/sign-in', req.url)
+    signInUrl.searchParams.set('redirect_url', req.url)
+    return NextResponse.redirect(signInUrl)
+  }
+
+  const user = await db.user.findUnique({ where: { clerkId: userId } })
+  if (!user) {
+    const signInUrl = new URL('/sign-in', req.url)
+    signInUrl.searchParams.set('redirect_url', req.url)
+    return NextResponse.redirect(signInUrl)
+  }
+
+  return user
+}


### PR DESCRIPTION
## Summary
- add helper to require DB user
- add API route to ensure user exists when signing in
- ensure user is created on sign-in/sign-up
- redirect to sign-in from API routes when DB user is missing

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68414cca9680833197fc9524746d6078