### PR TITLE
Add auth fetch wrapper and ensure user on SSO

### DIFF
--- a/app/[locale]/(auth)/sign-in/page.tsx
+++ b/app/[locale]/(auth)/sign-in/page.tsx
@@ -24,6 +24,7 @@ import {
 } from 'lucide-react';
 import { getClerkErrorMessage } from '@/lib/clerk/getClerkErrorMessage'
 import { ClerkError } from '@/types'
+import { fetchWithAuth } from '@/lib/fetchWithAuth'
 
 export default function SignInForm() {
   const t = useTranslations("auth");
@@ -52,7 +53,7 @@ export default function SignInForm() {
 
       if (result.status === 'complete') {
         await setActive({ session: result.createdSessionId })
-        await fetch('/api/ensure-user', { method: 'POST' })
+        await fetchWithAuth('/api/ensure-user', { method: 'POST' })
         router.push('/dashboard')
       }
     } catch (err: unknown) {

--- a/app/[locale]/(auth)/sign-up/page.tsx
+++ b/app/[locale]/(auth)/sign-up/page.tsx
@@ -27,6 +27,7 @@ import {
 } from 'lucide-react'
 import { ClerkError } from '@/types'
 import { getClerkErrorMessage } from '@/lib/clerk/getClerkErrorMessage'
+import { fetchWithAuth } from '@/lib/fetchWithAuth'
 
 export default function SignUpForm() {
   const t = useTranslations("auth");
@@ -108,7 +109,7 @@ export default function SignUpForm() {
 
       if (completeSignUp.status === 'complete') {
         await setActive({ session: completeSignUp.createdSessionId })
-        await fetch('/api/ensure-user', { method: 'POST' })
+        await fetchWithAuth('/api/ensure-user', { method: 'POST' })
         router.push('/dashboard')
       }
     } catch (err: unknown) {

--- a/app/sso-callback/page.tsx
+++ b/app/sso-callback/page.tsx
@@ -1,6 +1,16 @@
 // app/sso-callback/page.tsx
-import { AuthenticateWithRedirectCallback } from '@clerk/nextjs'
+import { AuthenticateWithRedirectCallback, useAuth } from '@clerk/nextjs'
+import { useEffect } from 'react'
+import { fetchWithAuth } from '@/lib/fetchWithAuth'
 
 export default function SSOCallback() {
+  const { isLoaded, userId } = useAuth()
+
+  useEffect(() => {
+    if (isLoaded && userId) {
+      fetchWithAuth('/api/ensure-user', { method: 'POST' })
+    }
+  }, [isLoaded, userId])
+
   return <AuthenticateWithRedirectCallback />
 }

--- a/context/AppContext.tsx
+++ b/context/AppContext.tsx
@@ -4,6 +4,7 @@
 import { createContext, useContext, useReducer, useEffect, ReactNode } from 'react'
 import { UserSettings } from '@/types'
 import { useUser } from '@clerk/nextjs'
+import { fetchWithAuth } from '@/lib/fetchWithAuth'
 
 // Global State Types
 interface GlobalAppState {
@@ -122,7 +123,7 @@ export function GlobalAppProvider({ children }: { children: ReactNode }) {
       try {
         dispatch({ type: 'SET_SETTINGS_LOADING', payload: true })
         
-        const response = await fetch('/api/settings')
+        const response = await fetchWithAuth('/api/settings')
         const data = await response.json()
         
         if (data.success && data.data) {
@@ -137,7 +138,7 @@ export function GlobalAppProvider({ children }: { children: ReactNode }) {
 
     async updateSettings(settings: UserSettings) {
       try {
-        const response = await fetch('/api/settings', {
+        const response = await fetchWithAuth('/api/settings', {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(settings)

--- a/hooks/use-customers.ts
+++ b/hooks/use-customers.ts
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback } from 'react'
 import { Customer, ApiResponse, PaginatedResponse, CreateCustomerData, UpdateCustomerData } from '@/types'
 import { toast } from 'sonner'
+import { fetchWithAuth } from '@/lib/fetchWithAuth'
 
 interface UseCustomersOptions {
   search?: string
@@ -84,7 +85,7 @@ export function useCustomers({
     try {
       setError(null)
 
-      const response = await fetch('/api/customers', {
+      const response = await fetchWithAuth('/api/customers', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -120,7 +121,7 @@ export function useCustomers({
     try {
       setError(null)
 
-      const response = await fetch(`/api/customers/${id}`, {
+      const response = await fetchWithAuth(`/api/customers/${id}`, {
         method: 'PUT',
         headers: {
           'Content-Type': 'application/json',
@@ -156,7 +157,7 @@ export function useCustomers({
     try {
       setError(null)
 
-      const response = await fetch(`/api/customers/${id}`, {
+      const response = await fetchWithAuth(`/api/customers/${id}`, {
         method: 'DELETE',
       })
 
@@ -219,7 +220,7 @@ export function useCustomer(id: string) {
       setLoading(true)
       setError(null)
 
-      const response = await fetch(`/api/customers/${id}`)
+      const response = await fetchWithAuth(`/api/customers/${id}`)
       const data: ApiResponse<Customer> = await response.json()
 
       if (!response.ok) {

--- a/hooks/use-enhanced-customers.ts
+++ b/hooks/use-enhanced-customers.ts
@@ -5,6 +5,7 @@ import { useState, useCallback } from 'react'
 import { Customer, ApiResponse, PaginatedResponse, CreateCustomerData, UpdateCustomerData } from '@/types'
 import { toast } from 'sonner'
 import { appCache, CACHE_KEYS, CACHE_TTL, cacheUtils, useCachedFetch } from '@/lib/cache'
+import { fetchWithAuth } from '@/lib/fetchWithAuth'
 
 interface UseCustomersOptions {
   search?: string
@@ -53,7 +54,7 @@ export function useEnhancedCustomers({
       ...(search && { search })
     })
 
-    const response = await fetch(`/api/customers?${params}`)
+    const response = await fetchWithAuth(`/api/customers?${params}`)
     const data: PaginatedResponse<Customer> = await response.json()
 
     if (!response.ok) {
@@ -85,7 +86,7 @@ export function useEnhancedCustomers({
   // Create customer
   const createCustomer = async (data: CreateCustomerData): Promise<Customer | null> => {
     try {
-      const response = await fetch('/api/customers', {
+      const response = await fetchWithAuth('/api/customers', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -124,7 +125,7 @@ export function useEnhancedCustomers({
   // Update customer
   const updateCustomer = async (id: string, data: UpdateCustomerData): Promise<Customer | null> => {
     try {
-      const response = await fetch(`/api/customers/${id}`, {
+      const response = await fetchWithAuth(`/api/customers/${id}`, {
         method: 'PUT',
         headers: {
           'Content-Type': 'application/json',
@@ -164,7 +165,7 @@ export function useEnhancedCustomers({
   // Delete customer
   const deleteCustomer = async (id: string): Promise<boolean> => {
     try {
-      const response = await fetch(`/api/customers/${id}`, {
+      const response = await fetchWithAuth(`/api/customers/${id}`, {
         method: 'DELETE',
       })
 
@@ -215,7 +216,7 @@ export function useEnhancedCustomer(id: string) {
   const cacheKey = CACHE_KEYS.CUSTOMER(id)
 
   const fetcher = useCallback(async (): Promise<Customer> => {
-    const response = await fetch(`/api/customers/${id}`)
+    const response = await fetchWithAuth(`/api/customers/${id}`)
     const data: ApiResponse<Customer> = await response.json()
 
     if (!response.ok) {

--- a/hooks/use-enhanced-invoices.ts
+++ b/hooks/use-enhanced-invoices.ts
@@ -5,6 +5,7 @@ import { useState, useCallback } from 'react'
 import { Invoice, ApiResponse, PaginatedResponse, CreateInvoiceData, UpdateInvoiceData, InvoiceStatus } from '@/types'
 import { toast } from 'sonner'
 import { appCache, CACHE_KEYS, CACHE_TTL, cacheUtils, useCachedFetch } from '@/lib/cache'
+import { fetchWithAuth } from '@/lib/fetchWithAuth'
 
 interface UseInvoicesOptions {
   search?: string
@@ -92,7 +93,7 @@ export function useEnhancedInvoices({
   // Create invoice
   const createInvoice = async (data: CreateInvoiceData): Promise<Invoice | null> => {
     try {
-      const response = await fetch('/api/invoices', {
+      const response = await fetchWithAuth('/api/invoices', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -131,7 +132,7 @@ export function useEnhancedInvoices({
   // Update invoice
   const updateInvoice = async (id: string, data: UpdateInvoiceData): Promise<Invoice | null> => {
     try {
-      const response = await fetch(`/api/invoices/${id}`, {
+      const response = await fetchWithAuth(`/api/invoices/${id}`, {
         method: 'PUT',
         headers: {
           'Content-Type': 'application/json',
@@ -171,7 +172,7 @@ export function useEnhancedInvoices({
   // Update invoice status
   const updateInvoiceStatus = async (id: string, status: InvoiceStatus): Promise<Invoice | null> => {
     try {
-      const response = await fetch(`/api/invoices/${id}/status`, {
+      const response = await fetchWithAuth(`/api/invoices/${id}/status`, {
         method: 'PATCH',
         headers: {
           'Content-Type': 'application/json',
@@ -211,7 +212,7 @@ export function useEnhancedInvoices({
   // Delete invoice
   const deleteInvoice = async (id: string): Promise<boolean> => {
     try {
-      const response = await fetch(`/api/invoices/${id}`, {
+      const response = await fetchWithAuth(`/api/invoices/${id}`, {
         method: 'DELETE',
       })
 
@@ -263,7 +264,7 @@ export function useEnhancedInvoice(id: string) {
   const cacheKey = CACHE_KEYS.INVOICE(id)
 
   const fetcher = useCallback(async (): Promise<Invoice> => {
-    const response = await fetch(`/api/invoices/${id}`)
+    const response = await fetchWithAuth(`/api/invoices/${id}`)
     const data: ApiResponse<Invoice> = await response.json()
 
     if (!response.ok) {
@@ -303,7 +304,7 @@ export function useEnhancedInvoiceStats() {
 
   const fetcher = useCallback(async () => {
     // כאן נטען את כל החשבוניות ונחשב סטטיסטיקות
-    const response = await fetch('/api/invoices?limit=1000')
+    const response = await fetchWithAuth('/api/invoices?limit=1000')
     const data: PaginatedResponse<Invoice> = await response.json()
 
     if (data.success && data.data) {

--- a/hooks/use-enhanced-notifications.ts
+++ b/hooks/use-enhanced-notifications.ts
@@ -3,6 +3,7 @@
 
 import { useState, useCallback } from 'react'
 import { toast } from 'sonner'
+import { fetchWithAuth } from '@/lib/fetchWithAuth'
 import { useGlobalApp } from '@/context/AppContext'
 import { appCache, CACHE_KEYS, CACHE_TTL, cacheUtils, useCachedFetch } from '@/lib/cache'
 
@@ -159,7 +160,7 @@ export function useEnhancedNotifications({
   // Mark all notifications as read
   const markAllAsRead = async (): Promise<void> => {
     try {
-      const response = await fetch('/api/notifications/mark-all-read', {
+      const response = await fetchWithAuth('/api/notifications/mark-all-read', {
         method: 'PATCH',
       })
 
@@ -291,7 +292,7 @@ export function useUnreadNotificationsCount() {
     loading: false, 
     refetch: async () => {
       // רענן דרך fetch של כל ההתראות
-      const response = await fetch('/api/notifications?limit=1&unreadOnly=true')
+      const response = await fetchWithAuth('/api/notifications?limit=1&unreadOnly=true')
       const data = await response.json()
       if (data.success) {
         actions.updateUnreadCount(data.unreadCount || 0)

--- a/hooks/use-notifications.ts
+++ b/hooks/use-notifications.ts
@@ -3,6 +3,7 @@
 
 import { useState, useEffect, useCallback } from 'react'
 import { toast } from 'sonner'
+import { fetchWithAuth } from '@/lib/fetchWithAuth'
 
 export interface Notification {
   id: string
@@ -151,7 +152,7 @@ export function useNotifications({
   // Mark all notifications as read
   const markAllAsRead = async (): Promise<void> => {
     try {
-      const response = await fetch('/api/notifications/mark-all-read', {
+      const response = await fetchWithAuth('/api/notifications/mark-all-read', {
         method: 'PATCH',
       })
 
@@ -308,7 +309,7 @@ export function useUnreadNotificationsCount() {
   const fetchUnreadCount = useCallback(async () => {
     try {
       setLoading(true)
-      const response = await fetch('/api/notifications?limit=1&unreadOnly=true')
+      const response = await fetchWithAuth('/api/notifications?limit=1&unreadOnly=true')
       const data = await response.json()
 
       if (data.success) {

--- a/lib/fetchWithAuth.ts
+++ b/lib/fetchWithAuth.ts
@@ -1,0 +1,21 @@
+export async function fetchWithAuth(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+  const res = await fetch(input, init);
+
+  if (res.redirected && res.url.includes('/sign-in')) {
+    if (typeof window !== 'undefined') {
+      window.location.href = res.url;
+    }
+    throw new Error('Redirecting to sign in');
+  }
+
+  if (res.status === 401) {
+    if (typeof window !== 'undefined') {
+      const redirectUrl = `/sign-in?redirect_url=${encodeURIComponent(window.location.href)}`;
+      window.location.href = redirectUrl;
+    }
+    throw new Error('Unauthorized');
+  }
+
+  return res;
+}
+


### PR DESCRIPTION
## Summary
- verify or create user during sign-in and sign-up via `fetchWithAuth`
- ensure user creation on SSO callback
- redirect unauthenticated requests via new `fetchWithAuth` utility

## Testing
- `npx jest` *(fails: Need to install jest)*

------
https://chatgpt.com/codex/tasks/task_e_68415186488c8331be164992da9fea6c